### PR TITLE
Only execute when variable is defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,9 @@
 - name: generic-directories | Make sure all directories are present
   file: path={{item.path}}{% if item.owner is defined %} owner={{item.owner}}{% endif %}{% if item.group is defined %} group={{item.group}}{% endif %}{% if item.mode is defined %} mode={{item.mode}}{% endif %} state=directory
   with_items: genericdirectories_directories
+  when: genericdirectories_directories is defined
 
 - name: generic-directories | Make sure all removed directories are not present
   file: path={{item.path}} state=absent
   with_items: genericdirectories_directories_removed
+  when: genericdirectories_directories_removed is defined


### PR DESCRIPTION
If you run the role on all your hosts but don't define the variables for all hosts, Ansible throws an error.
With this Fix, the playbook is only run when "genericdirectories_directories" or "genericdirectories_directories_removed" is defined.
