### PR TITLE
make with_items compatible with Ansible 2.2+

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,12 +8,12 @@
     mode: "{{ item.mode | default(omit) }}"
     recurse: "{{ item.recurse | default(omit) }}"
     state: "directory"
-  with_items: genericdirectories_directories
+  with_items: "{{ genericdirectories_directories }}"
   when: genericdirectories_directories is defined
 
 - name: generic-directories | Make sure all removed directories are not present
   file:
     path: "{{ item.path }}"
     state: "absent"
-  with_items: genericdirectories_directories_removed
+  with_items: "{{ genericdirectories_directories_removed }}"
   when: genericdirectories_directories_removed is defined


### PR DESCRIPTION
Updates `main.yml` inline with Ansible 2.2 syntax:

https://github.com/ansible/ansible-modules-core/issues/5509

```
TASK [ANXS.generic-directories : generic-directories | Make sure all directories are present] ***
task path: /my/path/to/roles/ANXS.generic-directories/tasks/main.yml:3
fatal: [rancher-test4.localdomain]: FAILED! => {
    "failed": true, 
    "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'ansible.vars.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'path'\n\nThe error appears to have been in '/my/path/to/roles/ANXS.generic-directories/tasks/main.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"generic-directories | Make sure all directories are present\"\n  ^ here\n"
}
```

thanks for this role by the way, just saved me a job :)